### PR TITLE
Cholesky branch: clip penalty eigenspectrum and add whitening latents

### DIFF
--- a/src/log_psplines/psplines/initialisation.py
+++ b/src/log_psplines/psplines/initialisation.py
@@ -74,7 +74,7 @@ def init_basis_and_penalty(
     degree: int,
     n_grid_points: int,
     diff_matrix_order: int,
-    epsilon: float = 1e-6,
+    epsilon: float = 1e-3,
 ) -> Tuple[jnp.ndarray, jnp.ndarray]:
     """
     Generate B-spline basis matrix and penalty matrix.
@@ -89,7 +89,7 @@ def init_basis_and_penalty(
         Number of grid points
     diff_matrix_order : int
         Order of the differential operator for regularization
-    epsilon : float, default=1e-6
+    epsilon : float, default=1e-3
         Small constant for numerical stability
 
     Returns

--- a/src/log_psplines/samplers/univar/nuts.py
+++ b/src/log_psplines/samplers/univar/nuts.py
@@ -35,6 +35,8 @@ def bayesian_model(
     log_pdgrm: jnp.ndarray,
     lnspline_basis: jnp.ndarray,
     penalty_matrix: jnp.ndarray,
+    penalty_whiten: jnp.ndarray,
+    penalty_unwhiten_T: jnp.ndarray,
     ln_parametric: jnp.ndarray,
     alpha_phi,
     beta_phi,
@@ -46,12 +48,11 @@ def bayesian_model(
         delta_name="delta",
         phi_name="phi",
         weights_name="weights",
-        penalty_matrix=penalty_matrix,
+        penalty_whiten=penalty_whiten,
         alpha_phi=alpha_phi,
         beta_phi=beta_phi,
         alpha_delta=alpha_delta,
         beta_delta=beta_delta,
-        factor_name="ln_prior",
     )
 
     weights = block["weights"]
@@ -93,11 +94,15 @@ class NUTSSampler(UnivarBaseSampler):
             beta_delta=self.config.beta_delta,
             divide_phi_by_delta=True,
         )
+        weights_latent_0 = self.penalty_unwhiten_T @ (
+            self.spline_model.weights * jnp.sqrt(phi_0)
+        )
         init_strategy = init_to_value(
             values=dict(
                 delta=delta_0,
                 phi=jnp.log(phi_0),
                 weights=self.spline_model.weights,
+                weights_latent=weights_latent_0,
             )
         )
 
@@ -130,6 +135,8 @@ class NUTSSampler(UnivarBaseSampler):
             self.log_pdgrm,
             self.basis_matrix,
             self.penalty_matrix,
+            self.penalty_whiten,
+            self.penalty_unwhiten_T,
             self.log_parametric,
             self.config.alpha_phi,
             self.config.beta_phi,
@@ -219,17 +226,40 @@ class NUTSSampler(UnivarBaseSampler):
         self, weights: jnp.ndarray, phi: float, delta: float
     ) -> float:
         """Compute log posterior for given parameters via the NumPyro model."""
+        weights_arr = jnp.asarray(weights)
+        phi_arr = jnp.asarray(phi)
+        delta_arr = jnp.asarray(delta)
+        latent = self.penalty_unwhiten_T @ (weights_arr * jnp.sqrt(phi_arr))
         params = {
-            "weights": jnp.asarray(weights),
-            "phi": jnp.log(jnp.asarray(phi)),
-            "delta": jnp.asarray(delta),
+            "weights": weights_arr,
+            "weights_latent": latent,
+            "phi": jnp.log(phi_arr),
+            "delta": delta_arr,
         }
         return float(self._logpost_fn(params))
 
     def _prepare_logpost_params(self, samples: Dict[str, jnp.ndarray]):
         """Stack posterior samples into a pytree for log-density evaluation."""
-        return {
-            "weights": jnp.asarray(samples["weights"]),
-            "phi": jnp.asarray(samples["phi"]),
-            "delta": jnp.asarray(samples["delta"]),
+        weights = jnp.asarray(samples["weights"])
+        phi_log = jnp.asarray(samples["phi"])
+        delta = jnp.asarray(samples["delta"])
+        params: Dict[str, jnp.ndarray] = {
+            "weights": weights,
+            "phi": phi_log,
+            "delta": delta,
         }
+
+        latent_key = "weights_latent"
+        if latent_key in samples:
+            params[latent_key] = jnp.asarray(samples[latent_key])
+        else:
+            sqrt_phi = jnp.exp(0.5 * phi_log)
+            if weights.ndim == 1:
+                latent = self.penalty_unwhiten_T @ (weights * sqrt_phi)
+            else:
+                latent = (
+                    weights * sqrt_phi[:, None]
+                ) @ self.penalty_unwhiten_T.T
+            params[latent_key] = latent
+
+        return params


### PR DESCRIPTION
 - Increased the ridge added to every spline penalty (epsilon now 1e-3) and switched the sampler whitening to an eigen-based transform that clips tiny eigenvalues
  (tol=1e-4) before building a reusable (P^{-1/2}). The helper now samples latent (z) values, maps them via the clipped whitening matrix, and keeps those latents
  around so we can regenerate log posteriors without relying on the old numpyro.factor correction (src/log_psplines/psplines/initialisation.py, src/log_psplines/
  samplers/utils.py).
  - Updated the univariate and multivariate NUTS samplers to consume the new whitening matrices, seed initial latent values, and rebuild latents on the fly when
  evaluating log densities; verbose runs now print per-matrix eigenvalue stats so we can see which directions were clipped (src/log_psplines/samplers/univar/
  univar_base.py, src/log_psplines/samplers/univar/nuts.py, src/log_psplines/samplers/multivar/multivar_base.py, src/log_psplines/samplers/multivar/multivar_nuts.py).
  - Threaded the same whitening data through the blocked sampler so each per-channel run gets the clipped transforms and corresponding latent initialisations, while
  trimming the old log-prior bookkeeping (src/log_psplines/samplers/multivar/multivar_blocked_nuts.py).