### PR TITLE
Add Coarse-graining (univar)

### DIFF
--- a/src/log_psplines/coarse_grain/__init__.py
+++ b/src/log_psplines/coarse_grain/__init__.py
@@ -1,0 +1,17 @@
+"""Coarse-graining utilities for frequency-domain PSD data."""
+
+from .config import CoarseGrainConfig
+from .plotting import plot_coarse_vs_original
+from .preprocess import (
+    CoarseGrainSpec,
+    apply_coarse_graining_univar,
+    compute_binning_structure,
+)
+
+__all__ = [
+    "CoarseGrainConfig",
+    "CoarseGrainSpec",
+    "compute_binning_structure",
+    "apply_coarse_graining_univar",
+    "plot_coarse_vs_original",
+]

--- a/src/log_psplines/coarse_grain/config.py
+++ b/src/log_psplines/coarse_grain/config.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(slots=True)
+class CoarseGrainConfig:
+    """Configuration for frequency-domain coarse graining."""
+
+    enabled: bool = False
+    f_transition: float = 1e-3
+    n_log_bins: int = 1000
+    f_min: Optional[float] = None
+    f_max: Optional[float] = None
+
+    def as_dict(self) -> dict:
+        return {
+            "enabled": self.enabled,
+            "f_transition": self.f_transition,
+            "n_log_bins": self.n_log_bins,
+            "f_min": self.f_min,
+            "f_max": self.f_max,
+        }

--- a/src/log_psplines/coarse_grain/jax_ops.py
+++ b/src/log_psplines/coarse_grain/jax_ops.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+import jax
+import jax.numpy as jnp
+
+
+def coarse_grain_univar(
+    power: jnp.ndarray,
+    *,
+    mask_low: jnp.ndarray,
+    mask_high: jnp.ndarray,
+    sort_indices: jnp.ndarray,
+    bin_indices_sorted: jnp.ndarray,
+    bin_counts: jnp.ndarray,
+    n_low: int,
+    n_bins_high: int,
+) -> Tuple[jnp.ndarray, jnp.ndarray]:
+    """Coarse-grain a power spectrum using precomputed masks/bins."""
+
+    power_low = power[mask_low]
+    weights_low = jnp.ones_like(power_low)
+
+    if n_bins_high == 0:
+        power_coarse = power_low
+        weights = weights_low
+    else:
+        power_high = power[mask_high]
+        power_high_sorted = power_high[sort_indices]
+
+        bin_counts = jnp.asarray(bin_counts)
+        sum_power = jax.ops.segment_sum(
+            power_high_sorted,
+            bin_indices_sorted,
+            n_bins_high,
+        )
+        counts = jax.ops.segment_sum(
+            jnp.ones_like(power_high_sorted),
+            bin_indices_sorted,
+            n_bins_high,
+        )
+
+        counts = jnp.where(counts > 0, counts, 1.0)
+        mean_power = sum_power / counts
+
+        non_empty = bin_counts > 0
+        mean_power = mean_power[non_empty]
+        counts = counts[non_empty]
+
+        power_coarse = jnp.concatenate((power_low, mean_power))
+        weights = jnp.concatenate((weights_low, counts))
+
+    return power_coarse, weights

--- a/src/log_psplines/coarse_grain/plotting.py
+++ b/src/log_psplines/coarse_grain/plotting.py
@@ -1,0 +1,64 @@
+"""Plotting helpers for coarse-grained periodograms."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from .preprocess import CoarseGrainSpec, apply_coarse_graining_univar
+
+
+def plot_coarse_vs_original(
+    freqs: np.ndarray,
+    power: np.ndarray,
+    spec: CoarseGrainSpec,
+    transition_freq: float = None,
+    scaling_factor: float = 1.0,
+    *,
+    ax: Optional[plt.Axes] = None,
+) -> plt.Figure:
+    """Plot original and coarse-grained periodograms for visual comparison."""
+
+    freqs = np.asarray(freqs, dtype=np.float64)
+    power = np.asarray(power, dtype=np.float64)
+
+    if ax is None:
+        fig, ax = plt.subplots()
+    else:
+        fig = ax.figure
+
+    selected_power = power[spec.selection_mask]
+    coarse_power, _ = apply_coarse_graining_univar(selected_power, spec)
+
+    n_orig = freqs.size
+    n_coarse = spec.f_coarse.size
+
+    ax.loglog(
+        freqs,
+        power * scaling_factor,
+        color="#1f77b4",
+        alpha=0.6,
+        label=f"Original [n={n_orig}]",
+    )
+    ax.loglog(
+        spec.f_coarse,
+        coarse_power * scaling_factor,
+        linestyle="-",
+        color="#d62728",
+        label=f"Coarse-grained [n={n_coarse}]",
+    )
+    if transition_freq is not None:
+        ax.axvline(
+            transition_freq,
+            color="gray",
+            linestyle="--",
+            label=f"Transition freq. ({transition_freq:.2e} Hz)",
+        )
+
+    ax.set_xlabel("Frequency [Hz]")
+    ax.set_ylabel("PSD [1/Hz]")
+    ax.legend()
+    fig.tight_layout()
+    return fig, ax

--- a/src/log_psplines/coarse_grain/preprocess.py
+++ b/src/log_psplines/coarse_grain/preprocess.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+
+
+@dataclass(slots=True)
+class CoarseGrainSpec:
+    """Static binning information for coarse-grained frequency data."""
+
+    f_coarse: np.ndarray
+    selection_mask: np.ndarray
+    mask_low: np.ndarray
+    mask_high: np.ndarray
+    bin_indices: np.ndarray
+    sort_indices: np.ndarray
+    bin_counts: np.ndarray
+    n_low: int
+    n_bins_high: int
+
+
+def compute_binning_structure(
+    freqs: np.ndarray,
+    *,
+    f_transition: float,
+    n_log_bins: int,
+    f_min: Optional[float] = None,
+    f_max: Optional[float] = None,
+) -> CoarseGrainSpec:
+    """Compute coarse-graining bins for a monotonically increasing frequency grid."""
+
+    if freqs.ndim != 1:
+        raise ValueError("freqs must be a 1-D array")
+    if not np.all(np.diff(freqs) >= 0):
+        raise ValueError("freqs must be monotonically increasing")
+    if n_log_bins <= 0:
+        raise ValueError("n_log_bins must be positive")
+    if f_transition <= 0:
+        raise ValueError("f_transition must be positive")
+
+    f_min = freqs[0] if f_min is None else max(f_min, freqs[0])
+    f_max = freqs[-1] if f_max is None else min(f_max, freqs[-1])
+    if f_max <= f_min:
+        raise ValueError("f_max must be greater than f_min after clamping")
+
+    in_range = (freqs >= f_min) & (freqs <= f_max)
+    if not np.any(in_range):
+        raise ValueError("No frequencies fall within the requested range")
+
+    selected_freqs = freqs[in_range]
+    mask_low_full = (freqs >= f_min) & (freqs <= f_transition)
+    mask_high_full = (freqs > f_transition) & (freqs <= f_max)
+
+    mask_low = mask_low_full[in_range]
+    mask_high = mask_high_full[in_range]
+
+    n_low = int(mask_low.sum())
+
+    high_freqs = selected_freqs[mask_high]
+    if high_freqs.size == 0:
+        # No high-frequency bins; only low frequencies retained
+        return CoarseGrainSpec(
+            f_coarse=selected_freqs,
+            mask_low=mask_low,
+            mask_high=mask_high,
+            bin_indices=np.array([], dtype=np.int32),
+            sort_indices=np.array([], dtype=np.int32),
+            bin_counts=np.array([], dtype=np.int32),
+            n_low=n_low,
+            n_bins_high=0,
+        )
+
+    # Build logarithmic bin edges for the high-frequency region
+    high_min = max(f_transition, high_freqs[0])
+    edges = np.logspace(
+        np.log10(high_min),
+        np.log10(f_max),
+        num=n_log_bins + 1,
+        base=10.0,
+    )
+    # Ensure edges cover the entire high-frequency range
+    edges[0] = min(edges[0], high_min)
+    edges[-1] = max(edges[-1], f_max)
+
+    # Assign bins (0-indexed). Points below first edge get bin -1; clamp to 0.
+    raw_indices = np.digitize(high_freqs, edges[1:-1], right=False)
+    unique_bins, reindexed = np.unique(raw_indices, return_inverse=True)
+    n_bins_high = int(unique_bins.size)
+
+    sort_indices = np.argsort(reindexed, kind="stable")
+    sorted_bins = reindexed[sort_indices]
+
+    # Count points per bin
+    bin_counts = np.bincount(sorted_bins, minlength=n_bins_high)
+
+    # Compute representative frequency per bin (mean of members)
+    bin_sums = np.zeros(n_bins_high, dtype=np.float64)
+    np.add.at(bin_sums, sorted_bins, high_freqs[sort_indices])
+    bin_means = bin_sums / np.where(bin_counts > 0, bin_counts, 1)
+
+    f_coarse = np.concatenate((selected_freqs[:n_low], bin_means))
+
+    return CoarseGrainSpec(
+        f_coarse=f_coarse,
+        selection_mask=in_range,
+        mask_low=mask_low,
+        mask_high=mask_high,
+        bin_indices=reindexed,
+        sort_indices=sort_indices,
+        bin_counts=bin_counts,
+        n_low=n_low,
+        n_bins_high=n_bins_high,
+    )
+
+
+def apply_coarse_graining_univar(
+    power: np.ndarray,
+    spec: CoarseGrainSpec,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Apply coarse graining to a power array using ``CoarseGrainSpec``."""
+
+    if power.ndim != 1:
+        raise ValueError("power must be 1-D")
+    if power.size != spec.mask_low.size:
+        raise ValueError("power length must match selected frequency count")
+
+    power_low = power[spec.mask_low]
+
+    if spec.n_bins_high == 0:
+        weights = np.ones_like(power_low, dtype=np.float64)
+        return power_low, weights
+
+    power_high = power[spec.mask_high]
+    power_high_sorted = power_high[spec.sort_indices]
+    sorted_bins = spec.bin_indices[spec.sort_indices]
+
+    sum_power = np.bincount(
+        sorted_bins,
+        weights=power_high_sorted,
+        minlength=spec.n_bins_high,
+    )
+    counts = spec.bin_counts.astype(np.float64)
+    means = np.divide(
+        sum_power,
+        np.where(counts > 0, counts, 1),
+        out=np.zeros_like(sum_power),
+        where=counts > 0,
+    )
+
+    power_coarse = np.concatenate((power_low, means))
+    weights = np.concatenate(
+        (
+            np.ones_like(power_low, dtype=np.float64),
+            counts,
+        )
+    )
+    return power_coarse, weights

--- a/src/log_psplines/mcmc.py
+++ b/src/log_psplines/mcmc.py
@@ -2,8 +2,14 @@ from typing import Literal, Optional, Union
 
 import arviz as az
 import jax.numpy as jnp
+import numpy as np
 from loguru import logger
 
+from .coarse_grain import (
+    CoarseGrainConfig,
+    apply_coarse_graining_univar,
+    compute_binning_structure,
+)
 from .datatypes import Periodogram
 from .datatypes.multivar import MultivarFFT, MultivariateTimeseries
 from .datatypes.univar import Timeseries
@@ -58,6 +64,7 @@ def run_mcmc(
     vi_guide: Optional[str] = None,
     vi_posterior_draws: int = 256,
     vi_progress_bar: Optional[bool] = None,
+    coarse_grain_config: Optional[CoarseGrainConfig | dict] = None,
     # MH specific
     target_accept_rate: float = 0.44,
     adaptation_window: int = 50,
@@ -115,6 +122,8 @@ def run_mcmc(
         Target acceptance probability for NUTS
     max_tree_depth : int, default=10
         Maximum tree depth for NUTS
+    coarse_grain_config : CoarseGrainConfig or dict, optional
+        Optional frequency coarse-graining configuration for univariate periodograms.
     target_accept_rate : float, default=0.44
         Target acceptance rate for MH
     adaptation_window : int, default=50
@@ -134,6 +143,13 @@ def run_mcmc(
     }
     sampler = sampler_aliases.get(sampler, sampler)
 
+    if coarse_grain_config is None:
+        cg_config = CoarseGrainConfig()
+    elif isinstance(coarse_grain_config, dict):
+        cg_config = CoarseGrainConfig(**coarse_grain_config)
+    else:
+        cg_config = coarse_grain_config
+
     # Keep true_psd on the original data scale. Any standardisation applied
     # to the observed data is tracked separately via the scaling_factor and
     # consistently undone inside ArviZ conversion before comparisons.
@@ -141,6 +157,7 @@ def run_mcmc(
 
     # Handle raw timeseries input - standardize automatically
     processed_data = None
+    freq_weights = None
 
     if isinstance(data, (Timeseries, MultivariateTimeseries)):
         # Standardize the raw timeseries for numerical stability
@@ -202,6 +219,41 @@ def run_mcmc(
                 "Frequency truncation removed all data points. Check fmin/fmax."
             )
 
+    if isinstance(processed_data, Periodogram) and cg_config.enabled:
+        spec = compute_binning_structure(
+            processed_data.freqs,
+            f_transition=cg_config.f_transition,
+            n_log_bins=cg_config.n_log_bins,
+            f_min=cg_config.f_min,
+            f_max=cg_config.f_max,
+        )
+
+        selection_mask = spec.selection_mask
+        power_selected = np.asarray(processed_data.power[selection_mask])
+        power_coarse, weights = apply_coarse_graining_univar(
+            power_selected, spec
+        )
+
+        processed_data = Periodogram(
+            spec.f_coarse,
+            power_coarse,
+            scaling_factor=processed_data.scaling_factor,
+            weights=weights,
+        )
+        freq_weights = weights.astype(np.float32)
+
+        if scaled_true_psd is not None:
+            try:
+                true_selected = np.asarray(scaled_true_psd)[selection_mask]
+                true_coarse, _ = apply_coarse_graining_univar(
+                    true_selected, spec
+                )
+                scaled_true_psd = true_coarse
+            except Exception:
+                logger.warning(
+                    "Could not coarse-grain provided true_psd; leaving unchanged."
+                )
+
     # Create model based on processed data type
     if isinstance(processed_data, Periodogram):
         # Univariate case
@@ -260,6 +312,7 @@ def run_mcmc(
             else 1.0
         ),  # Pass scaling info to sampler
         true_psd=scaled_true_psd,
+        freq_weights=freq_weights,
         **kwargs,
     )
 
@@ -296,6 +349,7 @@ def create_sampler(
     adaptation_window: int = 50,
     scaling_factor: float = 1.0,
     true_psd: Optional[jnp.ndarray] = None,
+    freq_weights: Optional[np.ndarray] = None,
     **kwargs,
 ):
     """Factory function to create appropriate sampler."""
@@ -317,6 +371,7 @@ def create_sampler(
         "compute_lnz": compute_lnz,
         "scaling_factor": scaling_factor,
         "true_psd": true_psd,
+        "freq_weights": freq_weights,
     }
 
     if isinstance(data, Periodogram):

--- a/src/log_psplines/samplers/base_sampler.py
+++ b/src/log_psplines/samplers/base_sampler.py
@@ -35,6 +35,7 @@ class SamplerConfig:
     compute_lnz: bool = False
     scaling_factor: float = 1.0  # To track any data scaling
     true_psd: Optional[jnp.ndarray] = None  # True PSD for diagnostics
+    freq_weights: Optional[np.ndarray] = None  # Optional frequency weights
 
     def __post_init__(self):
         if self.outdir is not None:

--- a/src/log_psplines/samplers/univar/metropolis_hastings.py
+++ b/src/log_psplines/samplers/univar/metropolis_hastings.py
@@ -92,6 +92,7 @@ class MetropolisHastingsSampler(UnivarBaseSampler):
             self.log_pdgrm,
             self.basis_matrix,
             self.log_parametric,
+            self.freq_weights,
             self.penalty_matrix,
             self.config.alpha_phi,
             self.config.beta_phi,
@@ -125,6 +126,7 @@ class MetropolisHastingsSampler(UnivarBaseSampler):
             self.log_pdgrm,
             self.basis_matrix,
             self.log_parametric,
+            self.freq_weights,
             self.penalty_matrix,
             self.config.alpha_phi,
             self.config.beta_phi,
@@ -145,6 +147,7 @@ class MetropolisHastingsSampler(UnivarBaseSampler):
                 self.log_pdgrm,
                 self.basis_matrix,
                 self.log_parametric,
+                self.freq_weights,
                 self.penalty_matrix,
                 subkey,
                 self.n_weights,
@@ -302,6 +305,7 @@ class MetropolisHastingsSampler(UnivarBaseSampler):
                             self.log_pdgrm,
                             self.basis_matrix,
                             self.log_parametric,
+                            self.freq_weights,
                             self.penalty_matrix,
                             self.config.alpha_phi,
                             self.config.beta_phi,
@@ -352,6 +356,7 @@ class MetropolisHastingsSampler(UnivarBaseSampler):
             log_pdgrm=self.log_pdgrm,
             basis_matrix=self.basis_matrix,
             log_parametric=self.log_parametric,
+            freq_weights=self.freq_weights,
             penalty_matrix=self.penalty_matrix,
             alpha_phi=self.config.alpha_phi,
             beta_phi=self.config.beta_phi,
@@ -419,6 +424,7 @@ def log_posterior(
     log_pdgrm: jnp.ndarray,
     basis_matrix: jnp.ndarray,
     log_parametric: jnp.ndarray,
+    freq_weights: jnp.ndarray,
     penalty_matrix: jnp.ndarray,
     alpha_phi: float,
     beta_phi: float,
@@ -426,7 +432,13 @@ def log_posterior(
     beta_delta: float,
 ) -> float:
     """Complete log posterior computation."""
-    log_like = log_likelihood(weights, log_pdgrm, basis_matrix, log_parametric)
+    log_like = log_likelihood(
+        weights,
+        log_pdgrm,
+        basis_matrix,
+        log_parametric,
+        freq_weights,
+    )
     log_prior_w = log_prior_weights(weights, phi, penalty_matrix)
     log_prior_phi_val = log_prior_phi(phi, delta, alpha_phi, beta_phi)
     log_prior_delta_val = log_prior_delta(delta, alpha_delta, beta_delta)
@@ -470,7 +482,7 @@ def gibbs_update_delta(
     return jax.random.gamma(rng_key, shape) / rate
 
 
-@partial(jax.jit, static_argnums=(9,))
+@partial(jax.jit, static_argnums=(10,))
 def update_weights_componentwise(
     weights: jnp.ndarray,
     step_sizes: jnp.ndarray,
@@ -479,6 +491,7 @@ def update_weights_componentwise(
     log_pdgrm: jnp.ndarray,
     basis_matrix: jnp.ndarray,
     log_parametric: jnp.ndarray,
+    freq_weights: jnp.ndarray,
     penalty_matrix: jnp.ndarray,
     rng_key: jax.random.PRNGKey,
     n_weights: int,
@@ -495,6 +508,7 @@ def update_weights_componentwise(
         log_pdgrm,
         basis_matrix,
         log_parametric,
+        freq_weights,
         penalty_matrix,
         alpha_phi,
         beta_phi,
@@ -521,6 +535,7 @@ def update_weights_componentwise(
             log_pdgrm,
             basis_matrix,
             log_parametric,
+            freq_weights,
             penalty_matrix,
             alpha_phi,
             beta_phi,
@@ -552,6 +567,7 @@ def update_weights_componentwise(
         log_pdgrm,
         basis_matrix,
         log_parametric,
+        freq_weights,
         penalty_matrix,
         alpha_phi,
         beta_phi,

--- a/src/log_psplines/samplers/univar/nuts.py
+++ b/src/log_psplines/samplers/univar/nuts.py
@@ -45,6 +45,7 @@ def bayesian_model(
     lnspline_basis: jnp.ndarray,
     penalty_matrix: jnp.ndarray,
     ln_parametric: jnp.ndarray,
+    freq_weights: jnp.ndarray,
     alpha_phi,
     beta_phi,
     alpha_delta,
@@ -64,7 +65,13 @@ def bayesian_model(
     )
 
     weights = block["weights"]
-    lnl = log_likelihood(weights, log_pdgrm, lnspline_basis, ln_parametric)
+    lnl = log_likelihood(
+        weights,
+        log_pdgrm,
+        lnspline_basis,
+        ln_parametric,
+        freq_weights,
+    )
     numpyro.factor("ln_likelihood", lnl)
 
 
@@ -145,6 +152,7 @@ class NUTSSampler(VIInitialisationMixin, UnivarBaseSampler):
             self.basis_matrix,
             self.penalty_matrix,
             self.log_parametric,
+            self.freq_weights,
             self.config.alpha_phi,
             self.config.beta_phi,
             self.config.alpha_delta,
@@ -198,6 +206,7 @@ class NUTSSampler(VIInitialisationMixin, UnivarBaseSampler):
             lnspline_basis=self.basis_matrix,
             penalty_matrix=self.penalty_matrix,
             ln_parametric=self.log_parametric,
+            freq_weights=self.freq_weights,
             alpha_phi=self.config.alpha_phi,
             beta_phi=self.config.beta_phi,
             alpha_delta=self.config.alpha_delta,

--- a/src/log_psplines/samplers/vi_init/adapters.py
+++ b/src/log_psplines/samplers/vi_init/adapters.py
@@ -84,6 +84,7 @@ def compute_vi_artifacts_univar(
             sampler.basis_matrix,
             sampler.penalty_matrix,
             sampler.log_parametric,
+            sampler.freq_weights,
             sampler.config.alpha_phi,
             sampler.config.beta_phi,
             sampler.config.alpha_delta,

--- a/tests/test_coarse_grain.py
+++ b/tests/test_coarse_grain.py
@@ -1,0 +1,176 @@
+import os
+
+import numpy as np
+import pytest
+
+from log_psplines.coarse_grain import (
+    CoarseGrainConfig,
+    apply_coarse_graining_univar,
+    compute_binning_structure,
+    plot_coarse_vs_original,
+)
+from log_psplines.plotting import plot_pdgrm
+
+
+def test_compute_binning_structure_simple():
+    freqs = np.linspace(1e-5, 1e-2, 100)
+    cfg = CoarseGrainConfig(
+        enabled=True,
+        f_transition=5e-3,
+        n_log_bins=5,
+        f_min=2e-5,
+        f_max=8e-3,
+    )
+
+    spec = compute_binning_structure(
+        freqs,
+        f_transition=cfg.f_transition,
+        n_log_bins=cfg.n_log_bins,
+        f_min=cfg.f_min,
+        f_max=cfg.f_max,
+    )
+
+    assert spec.f_coarse[0] == np.min(spec.f_coarse)
+    assert np.all(spec.f_coarse[:-1] <= spec.f_coarse[1:])
+    assert spec.n_low == spec.mask_low.sum()
+    assert spec.n_bins_high == spec.bin_counts.size
+
+    indices = np.nonzero(spec.selection_mask)[0]
+    power_selected = np.sin(indices * 0.1) ** 2 + 1.0
+    power_coarse, weights = apply_coarse_graining_univar(power_selected, spec)
+
+    assert power_coarse.shape[0] == weights.shape[0]
+    assert power_coarse.shape[0] == spec.f_coarse.shape[0]
+    assert np.all(weights[: spec.n_low] == 1.0)
+    assert np.isclose(
+        weights.sum(), spec.mask_low.sum() + spec.bin_counts.sum()
+    )
+
+
+@pytest.mark.skipif(
+    os.getenv("GITHUB_ACTIONS") is not None,
+    reason="Skip on GitHub Actions for time",
+)
+def test_coarse_lnl_with_univar_mcmc(outdir):
+    from log_psplines.example_datasets import ARData
+    from log_psplines.mcmc import run_mcmc
+
+    outdir = f"{outdir}/out_coarse_grain/univar"
+    os.makedirs(outdir, exist_ok=True)
+
+    ar_data = ARData(order=4, duration=1, fs=2048, seed=0)
+
+    standardized = ar_data.ts.standardise_for_psd()
+    periodogram_full = standardized.to_periodogram()
+
+    coarse_cfg = CoarseGrainConfig(
+        enabled=True,
+        f_transition=100.0,
+        f_max=ar_data.ts.fs / 2,
+        n_log_bins=300,
+    )
+
+    spec = compute_binning_structure(
+        np.asarray(periodogram_full.freqs),
+        f_transition=coarse_cfg.f_transition,
+        n_log_bins=coarse_cfg.n_log_bins,
+        f_min=coarse_cfg.f_min,
+        f_max=coarse_cfg.f_max,
+    )
+
+    fig, ax = plot_coarse_vs_original(
+        periodogram_full.freqs,
+        periodogram_full.power,
+        spec,
+        scaling_factor=standardized.scaling_factor,
+        transition_freq=coarse_cfg.f_transition,
+    )
+    ax = fig.gca()
+    ax.loglog(
+        ar_data.freqs, ar_data.psd_theoretical, "k--", label="Theoretical PSD"
+    )
+    fig.savefig(f"{outdir}/coarse_grain_example.png")
+
+    idata = run_mcmc(
+        ar_data.ts,
+        sampler="nuts",
+        n_knots=10,
+        n_samples=500,
+        n_warmup=500,
+        outdir=str(outdir),
+        rng_key=0,
+        compute_lnz=False,
+        init_from_vi=True,
+        verbose=False,
+        coarse_grain_config=coarse_cfg,
+        knot_kwargs=dict(method="uniform"),
+    )
+
+    idata2 = run_mcmc(
+        ar_data.ts,
+        sampler="nuts",
+        n_knots=10,
+        n_samples=500,
+        n_warmup=500,
+        outdir=str(outdir),
+        rng_key=0,
+        compute_lnz=False,
+        init_from_vi=True,
+        verbose=False,
+        knot_kwargs=dict(method="uniform"),
+    )
+
+    # check that the frequency coordinates match the coarse frequencies
+    freq_coords = np.asarray(idata.posterior_psd["psd"].coords["freq"].values)
+    obs_freqs = np.asarray(
+        idata.observed_data["periodogram"].coords["freq"].values
+    )
+    assert freq_coords.shape[0] == spec.f_coarse.shape[0]
+    assert obs_freqs.shape[0] == spec.f_coarse.shape[0]
+    assert np.allclose(freq_coords, spec.f_coarse, rtol=1e-6, atol=1e-9)
+
+    # finally, lets make a comparison PSD plot between coarse and full
+    fig, ax = plot_coarse_vs_original(
+        periodogram_full.freqs,
+        periodogram_full.power,
+        spec,
+        scaling_factor=standardized.scaling_factor,
+        transition_freq=coarse_cfg.f_transition,
+    )
+    ax = fig.gca()
+    ax.loglog(
+        ar_data.freqs, ar_data.psd_theoretical, "k--", label="Theoretical PSD"
+    )
+    plot_pdgrm(
+        idata=idata,
+        ax=ax,
+        show_data=False,
+        model_label="Coarse-grained NUTS",
+    )
+    plot_pdgrm(
+        idata=idata2,
+        ax=ax,
+        show_data=False,
+        model_label="Full freq",
+        model_color="tab:green",
+    )
+    ax.legend()
+    fig.savefig(f"{outdir}/coarse_vs_full_psd.png")
+
+    fig, ax = plot_pdgrm(
+        idata=idata,
+        show_data=False,
+        model_label="Coarse-grained NUTS",
+    )
+    plot_pdgrm(
+        idata=idata2,
+        ax=ax,
+        show_data=False,
+        model_label="Full freq NUTS",
+        model_color="tab:green",
+    )
+    ax.loglog(
+        ar_data.freqs, ar_data.psd_theoretical, "k--", label="Theoretical PSD"
+    )
+    ax.legend()
+    fig.savefig(f"{outdir}/coarse_vs_full_psd_just_splines.png")

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -5,6 +5,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from log_psplines.arviz_utils import compare_results, get_weights
+from log_psplines.coarse_grain import CoarseGrainConfig
 from log_psplines.example_datasets.ar_data import ARData
 from log_psplines.example_datasets.varma_data import VARMAData
 from log_psplines.mcmc import MultivariateTimeseries, run_mcmc
@@ -173,6 +174,13 @@ def test_mcmc(outdir: str, test_mode: str):
     )
     print(f"{ar_data.ts}")
 
+    # coarse_grain = CoarseGrainConfig(
+    #     enabled=True,
+    #     f_transition=10**2,
+    #     f_max=ar_data.ts.fs / 2,
+    #     n_log_bins=100,
+    # )
+
     for sampler in sampler_names:
         sampler_out = f"{outdir}/out_{sampler}"
         idata = run_mcmc(
@@ -186,6 +194,7 @@ def test_mcmc(outdir: str, test_mode: str):
             compute_lnz=compute_lnz,
             true_psd=ar_data.psd_theoretical,
             verbose=(test_mode != "fast"),
+            # coarse_grain=coarse_grain,
         )
 
         print(


### PR DESCRIPTION
## Coarse-graining

In "Reconstructing the spectral shape of a stochastic gravitational wave background with LISA" by Chiara Caprini a et al, they describe a 'coarse-grained' freq spectrum to reduce computational cost at high frequencies:

- Low freq kept sampe: Keeps all original resolution in low freq regime: eg from 3×10⁻⁵ Hz to 10⁻³ Hz (971 frequency bins)
- High freq binned: in range (10⁻³ Hz to 0.5 Hz) binned into 1000 log-spaced intervals
- Each bin uses weighted average of frequencies and data (weights: 1/σ²_i)
- Combined error: σ = (Σ 1/σ²_i)^(-1/2)


The likelihood function is:

$$\mathcal{L}(\vec{n}) \propto \exp\left( - \sum_i  \frac{1}{2} \left[ \frac{D_i - h^2 \Omega_s \left( f_i, \vec{n} \right) }{ \sigma_i}\right]^2 \right)$$

where:
- $\vec{n}$ = noise parameters
- $D_i$ = measured power at frequency $f_i$
- $h^2 \Omega_s(f_i, \vec{n})$ = noise power spectrum
- $\sigma_i$ = measurement uncertainty at frequency $f_i$


---

## My initial implementation: 

Red is the coarsened data (only different from original _after_ the transition frequency).

<img width="1920" height="1440" alt="coarse_vs_full_psd" src="https://github.com/user-attachments/assets/e0bae7bf-ca65-4f13-90b1-f51d286e09c8" />

The MCMC with the coarsened-data doesnt match the MCMC with the original data:
<img width="1200" height="900" alt="coarse_vs_full_psd_just_splines" src="https://github.com/user-attachments/assets/3bed869e-a86c-47f0-879c-a973dc033d4b" />


So something is off...
